### PR TITLE
README.md - Fixed mistake in package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ If you prefer to disable the command log completely, refer to the official Cypre
 To install this plugin, you can use either npm or yarn:
 
 ```bash
-npm install cypress-log-filter-plugin --save-dev
+npm install cypress-log-filter --save-dev
 ```
 
 or
 
 ```bash
-yarn add cypress-log-filter-plugin --dev
+yarn add cypress-log-filter --dev
 ```
 
 Then, import the plugin in your `support/e2e.js` file


### PR DESCRIPTION
@Brugui7 I don't know if you still maintain this package, but at least, if you publish it, let's be correct with package name ;) 

Problem:

```
$ npm i cypress-log-filter-plugin -D   

npm notice 
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/cypress-log-filter-plugin - Not found
npm ERR! 404 
npm ERR! 404  'cypress-log-filter-plugin@*' is not in this registry.

```

```
$ yarn add cypress-log-filter-plugin --dev

yarn add v1.22.19
warning package.json: No license field
warning No license field
[1/4] 🔍  Resolving packages...

error An unexpected error occurred: "https://registry.yarnpkg.com/cypress-log-filter-plugin: Not found".
info If you think this is a bug, please open a bug report with the information provided in "/Users/lund/projects_forks/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```


Real package name is `cypress-log-filter` and it's visible on NPMJS.com:
https://www.npmjs.com/package/cypress-log-filter

